### PR TITLE
Apvts

### DIFF
--- a/Source/GUI/EnvComp.cpp
+++ b/Source/GUI/EnvComp.cpp
@@ -2,7 +2,9 @@
 #include "EnvComp.h"
 
 //==============================================================================
-EnvComp::EnvComp()
+EnvComp::EnvComp(int num, juce::AudioProcessorValueTreeState& apvtsRef)
+    : envNum(num),
+      apvtsRef(apvtsRef)
 {
     initializeSlider(attackSlider, "A", 0.0, 5.0, 0.01, 0.1, true);
     initializeSlider(decaySlider, "D", 0.0, 5.0, 0.01, 0.1, true);

--- a/Source/GUI/EnvComp.cpp
+++ b/Source/GUI/EnvComp.cpp
@@ -4,7 +4,12 @@
 //==============================================================================
 EnvComp::EnvComp(int num, juce::AudioProcessorValueTreeState& apvtsRef)
     : envNum(num),
-      apvtsRef(apvtsRef)
+      apvtsRef(apvtsRef),
+      attackAttachment(apvtsRef, "ATTACK_" + std::to_string(num), attackSlider),
+      decayAttachment(apvtsRef, "DECAY_" + std::to_string(num), decaySlider),
+      sustainAttachment(apvtsRef, "SUSTAIN_" + std::to_string(num), sustainSlider),
+      releaseAttachment(apvtsRef, "RELEASE_" + std::to_string(num), releaseSlider)
+ 
 {
     initializeSlider(attackSlider, "A", 0.0, 5.0, 0.01, 0.1, true);
     initializeSlider(decaySlider, "D", 0.0, 5.0, 0.01, 0.1, true);

--- a/Source/GUI/EnvComp.cpp
+++ b/Source/GUI/EnvComp.cpp
@@ -4,10 +4,10 @@
 //==============================================================================
 EnvComp::EnvComp()
 {
-    initializeSlider(attackSlider, "A", 0.0, 5.0, 0.01, 0.1);
-    initializeSlider(decaySlider, "D", 0.0, 5.0, 0.01, 0.1);
-    initializeSlider(sustainSlider, "S", 0.0, 1.0, 0.01, 0.8);
-    initializeSlider(releaseSlider, "R", 0.0, 5.0, 0.01, 0.1);
+    initializeSlider(attackSlider, "A", 0.0, 5.0, 0.01, 0.1, true);
+    initializeSlider(decaySlider, "D", 0.0, 5.0, 0.01, 0.1, true);
+    initializeSlider(sustainSlider, "S", 0.0, 1.0, 0.01, 0.8, false);
+    initializeSlider(releaseSlider, "R", 0.0, 5.0, 0.01, 0.1, true);
     
     // Kind of just guessed on these colors. Perhaps later we can have some
     // global color obj.
@@ -26,7 +26,7 @@ EnvComp::~EnvComp()
 {
 }
 
-void EnvComp::initializeSlider(juce::Slider& slider, const juce::String& name, double min, double max, double interval, double initialValue)
+void EnvComp::initializeSlider(juce::Slider& slider, const juce::String& name, double min, double max, double interval, double initialValue, bool skewed)
 {
     addAndMakeVisible(slider);
     slider.setSliderStyle(juce::Slider::RotaryHorizontalVerticalDrag);
@@ -34,6 +34,7 @@ void EnvComp::initializeSlider(juce::Slider& slider, const juce::String& name, d
     slider.setRange(min, max, interval);
     slider.setValue(initialValue);
     slider.addListener(this);
+    if (skewed) slider.setSkewFactorFromMidPoint(1.0); // skews a, d, and r to have 1 second be the midpoint
 
     juce::Label* label = nullptr;
     if (name == "A") label = &attackLabel;

--- a/Source/GUI/EnvComp.h
+++ b/Source/GUI/EnvComp.h
@@ -25,7 +25,7 @@ public:
     void resized() override;
 
 private:
-    void initializeSlider(juce::Slider& slider, const juce::String& name, double min, double max, double interval, double initialValue);
+    void initializeSlider(juce::Slider& slider, const juce::String& name, double min, double max, double interval, double initialValue, bool skewed);
     void sliderValueChanged(juce::Slider* slider) override;
     void setSliderBounds(juce::Slider& slider, juce::Label& label, juce::Rectangle<int> bounds);
     juce::Slider attackSlider;

--- a/Source/GUI/EnvComp.h
+++ b/Source/GUI/EnvComp.h
@@ -35,6 +35,13 @@ private:
     
     int envNum;
     juce::AudioProcessorValueTreeState& apvtsRef;
+    
+    juce::AudioProcessorValueTreeState::SliderAttachment attackAttachment;
+    juce::AudioProcessorValueTreeState::SliderAttachment decayAttachment;
+    juce::AudioProcessorValueTreeState::SliderAttachment sustainAttachment;
+    juce::AudioProcessorValueTreeState::SliderAttachment releaseAttachment;
+    
+
 
     juce::Label attackLabel;
     juce::Label decayLabel;

--- a/Source/GUI/EnvComp.h
+++ b/Source/GUI/EnvComp.h
@@ -18,7 +18,7 @@
 class EnvComp : public juce::Component, private juce::Slider::Listener
 {
 public:
-    EnvComp();
+    EnvComp(int num, juce::AudioProcessorValueTreeState& apvtsRef);
     ~EnvComp() override;
 
     void paint(juce::Graphics&) override;
@@ -32,6 +32,9 @@ private:
     juce::Slider decaySlider;
     juce::Slider sustainSlider;
     juce::Slider releaseSlider;
+    
+    int envNum;
+    juce::AudioProcessorValueTreeState& apvtsRef;
 
     juce::Label attackLabel;
     juce::Label decayLabel;

--- a/Source/GUI/FilterComp.cpp
+++ b/Source/GUI/FilterComp.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
   ==============================================================================
 
     FilterComp.cpp
@@ -301,5 +301,3 @@ void FilterComp::sliderValueChanged(juce::Slider* slider)
     }
     repaint();
 }
-
-

--- a/Source/GUI/FilterComp.cpp
+++ b/Source/GUI/FilterComp.cpp
@@ -34,7 +34,7 @@ FilterComp::FilterComp()
     // Configure cutoff frequency knob (20 Hz to 20 kHz, logarithmic behavior)
     cutoffSlider.setRange(20.0, 20000.0, 1.0);
     cutoffSlider.setSkewFactorFromMidPoint(1000.0);
-    cutoffSlider.setValue(1000.0);
+    cutoffSlider.setValue(20000.0);
     addAndMakeVisible(cutoffSlider);
 
     // Configure resonance (Q) knob (range from 0.1 to 10, default 0.707 for Butterworth)

--- a/Source/GUI/FilterComp.cpp
+++ b/Source/GUI/FilterComp.cpp
@@ -13,7 +13,7 @@
 
 FilterComp::FilterComp(juce::AudioProcessorValueTreeState& apvtsRef) : apvtsRef(apvtsRef),
 cutoffAttachment(apvtsRef, "CUTOFF", cutoffSlider),
-resonanceAttachment(apvtsRef, "RESONACE", resonanceSlider)
+resonanceAttachment(apvtsRef, "RESONANCE", resonanceSlider)
 {
 
 

--- a/Source/GUI/FilterComp.cpp
+++ b/Source/GUI/FilterComp.cpp
@@ -11,7 +11,9 @@
 #include <JuceHeader.h>
 #include "FilterComp.h"
 
-FilterComp::FilterComp()
+FilterComp::FilterComp(juce::AudioProcessorValueTreeState& apvtsRef) : apvtsRef(apvtsRef),
+cutoffAttachment(apvtsRef, "CUTOFF", cutoffSlider),
+resonanceAttachment(apvtsRef, "RESONACE", resonanceSlider)
 {
 
 

--- a/Source/GUI/FilterComp.h
+++ b/Source/GUI/FilterComp.h
@@ -16,7 +16,7 @@ class FilterComp : public juce::Component,
     public juce::Slider::Listener
 {
 public:
-    FilterComp();
+    FilterComp(juce::AudioProcessorValueTreeState& apvtsRef);
     ~FilterComp() override;
 
     void paint(juce::Graphics& g) override;
@@ -29,8 +29,13 @@ public:
     void setSampleRate(float newSampleRate) { sampleRate = newSampleRate; repaint(); }
 
 private:
+    juce::AudioProcessorValueTreeState& apvtsRef;
+    
     juce::Slider cutoffSlider;
     juce::Slider resonanceSlider;
+    
+    juce::AudioProcessorValueTreeState::SliderAttachment cutoffAttachment;
+    juce::AudioProcessorValueTreeState::SliderAttachment resonanceAttachment;
 
     juce::Label freqLabel;
     juce::Label qLabel;

--- a/Source/GUI/LFOComp.h
+++ b/Source/GUI/LFOComp.h
@@ -18,15 +18,19 @@
 class LFOComp  : public juce::Component
 {
 public:
-    LFOComp();
+    LFOComp(juce::AudioProcessorValueTreeState& apvtsRef);
     ~LFOComp() override;
 
     void paint (juce::Graphics&) override;
     void resized() override;
+    void setAlgIndexParameter(int newValue);
 
 
 private:
-    int algo_ind;
+    juce::AudioProcessorValueTreeState& apvtsRef;
+    
+//    int algo_ind; the new way to access this is with apvtsRef.getRawParameterValue("ALG_INDEX")->load()
+    
     std::unique_ptr<juce::DrawableButton> next_b;
     std::unique_ptr<juce::DrawableButton> prev_b;
     juce::Image image;

--- a/Source/GUI/OscComp.cpp
+++ b/Source/GUI/OscComp.cpp
@@ -14,8 +14,8 @@ OscComp::OscComp(const juce::String& title)
 {
     // setup the sliders
     initializeSlider(oscLevelSlider, oscLevelLabel, "Level", juce::Slider::SliderStyle::RotaryHorizontalVerticalDrag, 0.0, 1.0, 0.01, 0.5);
-    initializeSlider(oscFineTuneSlider, oscFineTuneLabel, "Fine", juce::Slider::SliderStyle::RotaryHorizontalVerticalDrag, 0.0, 100.0, 0.01, 0.0);
-    initializeSlider(oscRatioSlider, oscRatioLabel, "Ratio", juce::Slider::SliderStyle::RotaryHorizontalVerticalDrag, 1.0, 12.0, 1.0, 1.0);
+    initializeSlider(oscFineTuneSlider, oscFineTuneLabel, "Fine", juce::Slider::SliderStyle::RotaryHorizontalVerticalDrag, 0.0, 100.0, 1.0, 0.0);
+    initializeSlider(oscRatioSlider, oscRatioLabel, "Coarse", juce::Slider::SliderStyle::RotaryHorizontalVerticalDrag, 1.0, 12.0, 1.0, 1.0);
     
     // again kinda spamming the same colors everywhere, we can do a pr to pull it out
     juce::Colour mainBlue(0x91, 0xC9, 0xB5);

--- a/Source/GUI/OscComp.cpp
+++ b/Source/GUI/OscComp.cpp
@@ -14,8 +14,8 @@ OscComp::OscComp(const juce::String& title)
 {
     // setup the sliders
     initializeSlider(oscLevelSlider, oscLevelLabel, "Level", juce::Slider::SliderStyle::RotaryHorizontalVerticalDrag, 0.0, 1.0, 0.01, 0.5);
-    initializeSlider(oscFineTuneSlider, oscFineTuneLabel, "Fine", juce::Slider::SliderStyle::RotaryHorizontalVerticalDrag, -50.0, 50.0, 0.01, 0.0);
-    initializeSlider(oscRatioSlider, oscRatioLabel, "Ratio", juce::Slider::SliderStyle::RotaryHorizontalVerticalDrag, -12.0, 12.0, 1.0, 0.0);
+    initializeSlider(oscFineTuneSlider, oscFineTuneLabel, "Fine", juce::Slider::SliderStyle::RotaryHorizontalVerticalDrag, 0.0, 100.0, 0.01, 0.0);
+    initializeSlider(oscRatioSlider, oscRatioLabel, "Ratio", juce::Slider::SliderStyle::RotaryHorizontalVerticalDrag, 1.0, 12.0, 1.0, 1.0);
     
     // again kinda spamming the same colors everywhere, we can do a pr to pull it out
     juce::Colour mainBlue(0x91, 0xC9, 0xB5);

--- a/Source/GUI/OscComp.cpp
+++ b/Source/GUI/OscComp.cpp
@@ -8,20 +8,26 @@
   ==============================================================================
 */
 #include "OscComp.h"
+#include <string>
 
-OscComp::OscComp(const juce::String& title)
-    : tabTitle(title)
+OscComp::OscComp(int num, juce::AudioProcessorValueTreeState& apvtsRef)
+    : oscNum(num),
+      apvtsRef(apvtsRef),
+      levelAttachment(apvtsRef, "LEVEL_" + std::to_string(oscNum), oscLevelSlider),
+      fineAttachment(apvtsRef, "FINE_" + std::to_string(oscNum), oscFineSlider),
+      coarseAttachment(apvtsRef, "COARSE_" + std::to_string(oscNum), oscCoarseSlider)
+      
 {
     // setup the sliders
     initializeSlider(oscLevelSlider, oscLevelLabel, "Level", juce::Slider::SliderStyle::RotaryHorizontalVerticalDrag, 0.0, 1.0, 0.01, 0.5);
-    initializeSlider(oscFineTuneSlider, oscFineTuneLabel, "Fine", juce::Slider::SliderStyle::RotaryHorizontalVerticalDrag, 0.0, 100.0, 1.0, 0.0);
-    initializeSlider(oscRatioSlider, oscRatioLabel, "Coarse", juce::Slider::SliderStyle::RotaryHorizontalVerticalDrag, 1.0, 12.0, 1.0, 1.0);
+    initializeSlider(oscFineSlider, oscFineLabel, "Fine", juce::Slider::SliderStyle::RotaryHorizontalVerticalDrag, 0.0, 100.0, 1.0, 0.0);
+    initializeSlider(oscCoarseSlider, oscCoarseLabel, "Coarse", juce::Slider::SliderStyle::RotaryHorizontalVerticalDrag, 1.0, 12.0, 1.0, 1.0);
     
     // again kinda spamming the same colors everywhere, we can do a pr to pull it out
     juce::Colour mainBlue(0x91, 0xC9, 0xB5);
     juce::Colour accentBlue(0x5B, 0x8F, 0x7E);
     
-    for (auto* slider : {&oscLevelSlider, &oscFineTuneSlider, &oscRatioSlider})
+    for (auto* slider : {&oscLevelSlider, &oscFineSlider, &oscCoarseSlider})
     {
         slider->setColour(juce::Slider::rotarySliderFillColourId, mainBlue);
         slider->setColour(juce::Slider::rotarySliderOutlineColourId, accentBlue);
@@ -29,7 +35,7 @@ OscComp::OscComp(const juce::String& title)
     }
     
     // TODO: juce funt deprecated
-    for (auto* label : {&oscLevelLabel, &oscFineTuneLabel, &oscRatioLabel})
+    for (auto* label : {&oscLevelLabel, &oscFineLabel, &oscCoarseLabel})
     {
         label->setFont(juce::Font(14.0f, juce::Font::bold));
         label->setColour(juce::Label::textColourId, mainBlue);
@@ -58,8 +64,8 @@ void OscComp::paint(juce::Graphics& g)
     juce::Path wavePath;
     float amplitude = height / 2.0f * oscLevelSlider.getValue();
     float centerY = graphBounds.getCentreY();
-    float ratio = oscRatioSlider.getValue();
-    float fineTune = oscFineTuneSlider.getValue() / 25.0f;
+    float ratio = oscCoarseSlider.getValue();
+    float fineTune = oscFineSlider.getValue() / 25.0f;
     
     // The thing about fractional ratios
     ratio = std::max(1.0f, std::abs(ratio));
@@ -110,11 +116,11 @@ void OscComp::paint(juce::Graphics& g)
     g.drawText(valueStr(oscLevelSlider.getValue()),
               oscLevelSlider.getBounds().translated(0, -15),
               juce::Justification::centred);
-    g.drawText(valueStr(oscFineTuneSlider.getValue()),
-              oscFineTuneSlider.getBounds().translated(0, -15),
+    g.drawText(valueStr(oscFineSlider.getValue()),
+              oscFineSlider.getBounds().translated(0, -15),
               juce::Justification::centred);
-    g.drawText(valueStr(oscRatioSlider.getValue()),
-              oscRatioSlider.getBounds().translated(0, -15),
+    g.drawText(valueStr(oscCoarseSlider.getValue()),
+              oscCoarseSlider.getBounds().translated(0, -15),
               juce::Justification::centred);
 }
 
@@ -138,13 +144,13 @@ void OscComp::resized()
     auto ratioArea = sliderArea;
     
     oscLevelSlider.setBounds(levelArea.withSizeKeepingCentre(knobSize, knobSize));
-    oscFineTuneSlider.setBounds(fineArea.withSizeKeepingCentre(knobSize, knobSize));
-    oscRatioSlider.setBounds(ratioArea.withSizeKeepingCentre(knobSize, knobSize));
+    oscFineSlider.setBounds(fineArea.withSizeKeepingCentre(knobSize, knobSize));
+    oscCoarseSlider.setBounds(ratioArea.withSizeKeepingCentre(knobSize, knobSize));
     
     // labels below sliders
     oscLevelLabel.setBounds(oscLevelSlider.getBounds().withHeight(20).translated(0, knobSize/2 + 5));
-    oscFineTuneLabel.setBounds(oscFineTuneSlider.getBounds().withHeight(20).translated(0, knobSize/2 + 5));
-    oscRatioLabel.setBounds(oscRatioSlider.getBounds().withHeight(20).translated(0, knobSize/2 + 5));
+    oscFineLabel.setBounds(oscFineSlider.getBounds().withHeight(20).translated(0, knobSize/2 + 5));
+    oscCoarseLabel.setBounds(oscCoarseSlider.getBounds().withHeight(20).translated(0, knobSize/2 + 5));
 }
 
 void OscComp::initializeSlider(juce::Slider& slider, juce::Label& label, const juce::String& name, juce::Slider::SliderStyle style, double min, double max, double interval, double initialValue)

--- a/Source/GUI/OscComp.h
+++ b/Source/GUI/OscComp.h
@@ -15,7 +15,7 @@
 class OscComp : public juce::Component, private juce::Slider::Listener
 {
 public:
-    OscComp(const juce::String& title = "title");
+    OscComp(int num, juce::AudioProcessorValueTreeState& apvtsRef);
     ~OscComp() override = default;
 
     void paint(juce::Graphics& g) override;
@@ -29,15 +29,20 @@ private:
     void sliderValueChanged(juce::Slider* slider) override;
     void updateLabel(juce::Label& label, const juce::String& name, double value);
 
-    juce::String tabTitle;
+    int oscNum;
+    juce::AudioProcessorValueTreeState& apvtsRef;
 
     juce::Slider oscLevelSlider;
-    juce::Slider oscFineTuneSlider;
-    juce::Slider oscRatioSlider;
+    juce::Slider oscFineSlider;
+    juce::Slider oscCoarseSlider;
+    
+    juce::AudioProcessorValueTreeState::SliderAttachment levelAttachment;
+    juce::AudioProcessorValueTreeState::SliderAttachment fineAttachment;
+    juce::AudioProcessorValueTreeState::SliderAttachment coarseAttachment;
 
     juce::Label oscLevelLabel;
-    juce::Label oscFineTuneLabel;
-    juce::Label oscRatioLabel;
+    juce::Label oscFineLabel;
+    juce::Label oscCoarseLabel;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(OscComp)
 };

--- a/Source/GUI/OscEnvParent.h
+++ b/Source/GUI/OscEnvParent.h
@@ -17,8 +17,11 @@
 class OscEnvParent : public juce::Component
 {
 public:
-    OscEnvParent(const juce::String& title)
-        : oscComp(title)
+    OscEnvParent(const int operatorNum, juce::AudioProcessorValueTreeState& apvtsRef)
+        : oscComp(operatorNum, apvtsRef),
+          envComp(operatorNum, apvtsRef),
+          operatorNum(operatorNum),
+          apvtsRef(apvtsRef)
     {
         addAndMakeVisible(oscComp);
         addAndMakeVisible(envComp);
@@ -36,6 +39,11 @@ public:
 private:
     OscComp oscComp;
     EnvComp envComp;
+    
+    //this class does not necessarily have any need to hold these references as they are passed to the children in the constuctor.
+    //I am leaving them here for convenience in case the need arises
+    int operatorNum;
+    juce::AudioProcessorValueTreeState& apvtsRef;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(OscEnvParent)
 };

--- a/Source/GUI/OscEnvTab.h
+++ b/Source/GUI/OscEnvTab.h
@@ -18,18 +18,18 @@
 class OscEnvTab : public juce::TabbedComponent
 {
 public:
-    OscEnvTab()
+    OscEnvTab(juce::AudioProcessorValueTreeState& apvtsRef)
         : juce::TabbedComponent(juce::TabbedButtonBar::TabsAtTop)
     {
         juce::Colour oscColor = juce::Colours::palevioletred;
         setTabBarDepth(30);
 
-        addTab("Osc 1", oscColor, new OscEnvParent("Osc 1"), true);
-        addTab("Osc 2", oscColor, new OscEnvParent("Osc 2"), true);
-        addTab("Osc 3", oscColor, new OscEnvParent("Osc 3"), true);
-        addTab("Osc 4", oscColor, new OscEnvParent("Osc 4"), true);
-        addTab("Osc 5", oscColor, new OscEnvParent("Osc 5"), true);
-        addTab("Osc 6", oscColor, new OscEnvParent("Osc 6"), true);
+        addTab("Osc 1", oscColor, new OscEnvParent(1, apvtsRef), true);
+        addTab("Osc 2", oscColor, new OscEnvParent(2, apvtsRef), true);
+        addTab("Osc 3", oscColor, new OscEnvParent(3, apvtsRef), true);
+        addTab("Osc 4", oscColor, new OscEnvParent(4, apvtsRef), true);
+        addTab("Osc 5", oscColor, new OscEnvParent(5, apvtsRef), true);
+        addTab("Osc 6", oscColor, new OscEnvParent(6, apvtsRef), true);
     }
 
     ~OscEnvTab() override = default;

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -11,7 +11,7 @@
 
 //==============================================================================
 OutsetAudioProcessorEditor::OutsetAudioProcessorEditor (OutsetAudioProcessor& p, juce::MidiKeyboardState& ks )
-    : AudioProcessorEditor (&p), audioProcessor (p), keyboard_comp(ks)
+    : AudioProcessorEditor (&p), audioProcessor (p), keyboard_comp(ks), osc_env_tab(audioProcessor.apvts)
 {
     double ratio = 4.0 / 3.0;
     setResizeLimits(400, 400 / ratio, 1200, 1200 / ratio);

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -11,7 +11,7 @@
 
 //==============================================================================
 OutsetAudioProcessorEditor::OutsetAudioProcessorEditor (OutsetAudioProcessor& p, juce::MidiKeyboardState& ks )
-    : AudioProcessorEditor (&p), audioProcessor (p), keyboard_comp(ks), osc_env_tab(audioProcessor.apvts), filter_comp(audioProcessor.apvts)
+    : AudioProcessorEditor (&p), audioProcessor (p), keyboard_comp(ks), osc_env_tab(audioProcessor.apvts), filter_comp(audioProcessor.apvts), lfo_comp(audioProcessor.apvts)
 {
     double ratio = 4.0 / 3.0;
     setResizeLimits(400, 400 / ratio, 1200, 1200 / ratio);

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -11,7 +11,7 @@
 
 //==============================================================================
 OutsetAudioProcessorEditor::OutsetAudioProcessorEditor (OutsetAudioProcessor& p, juce::MidiKeyboardState& ks )
-    : AudioProcessorEditor (&p), audioProcessor (p), keyboard_comp(ks), osc_env_tab(audioProcessor.apvts)
+    : AudioProcessorEditor (&p), audioProcessor (p), keyboard_comp(ks), osc_env_tab(audioProcessor.apvts), filter_comp(audioProcessor.apvts)
 {
     double ratio = 4.0 / 3.0;
     setResizeLimits(400, 400 / ratio, 1200, 1200 / ratio);

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -346,13 +346,22 @@ juce::AudioProcessorValueTreeState::ParameterLayout OutsetAudioProcessor::create
             0.8f));
     }
 
-    // Alg Index Parameter (1)
-    juce::NormalisableRange<float> algIndexRange(0.0f, 31.0f, 1.0f);
-    layout.add(std::make_unique<juce::AudioParameterFloat>(
-        juce::ParameterID("ALG_INDEX", 1),
-        "Alg Index",
-        algIndexRange,
-        0.0f));
+//    // Alg Index Parameter (1)
+//    juce::NormalisableRange<float> algIndexRange(0.0f, 31.0f, 1.0f);
+//    layout.add(std::make_unique<juce::AudioParameterFloat>(
+//        juce::ParameterID("ALG_INDEX", 1),
+//        "Alg Index",
+//        algIndexRange,
+//        0.0f));
+
+
+
+    layout.add(std::make_unique<juce::AudioParameterInt>(
+        juce::ParameterID("ALG_INDEX", 1), // Parameter ID
+        "Alg Index",                       // Parameter name
+        0,                                 // Minimum value
+        31,                                // Maximum value
+        0));                               // Default value
 
     return layout;
 }

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -160,12 +160,30 @@ void OutsetAudioProcessor::processBlock (juce::AudioBuffer<float>& buffer, juce:
     for (auto i = totalNumInputChannels; i < totalNumOutputChannels; ++i)
         buffer.clear (i, 0, buffer.getNumSamples());
     
+    
+    
     //our code (non-template stuff) starts here
+  
+    
+    
 	filter->setCutoffFrequency(1000.0f);
 	filter->setResonance(0.7f);
     keyboardState.processNextMidiBuffer(midiMessages, 0, buffer.getNumSamples(), true);
     splitBufferByEvents(buffer, midiMessages);
     filter->processBlock(buffer);
+    
+    
+    
+    //uncomment these to check that parameters and sliders are linked
+//    double cutoff = apvts.getRawParameterValue("CUTOFF")->load();
+//    double attack3 = apvts.getRawParameterValue("ATTACK_3")->load();
+//    double fine1 = apvts.getRawParameterValue("FINE_1")->load();
+//    
+//    
+//    DBG(cutoff);
+//    DBG(attack3);
+//    DBG(fine1);
+
 }
 
 void OutsetAudioProcessor::splitBufferByEvents(juce::AudioBuffer<float>& buffer,
@@ -345,14 +363,6 @@ juce::AudioProcessorValueTreeState::ParameterLayout OutsetAudioProcessor::create
             sustainRange,
             0.8f));
     }
-
-//    // Alg Index Parameter (1)
-//    juce::NormalisableRange<float> algIndexRange(0.0f, 31.0f, 1.0f);
-//    layout.add(std::make_unique<juce::AudioParameterFloat>(
-//        juce::ParameterID("ALG_INDEX", 1),
-//        "Alg Index",
-//        algIndexRange,
-//        0.0f));
 
 
 

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -245,6 +245,119 @@ void OutsetAudioProcessor::setStateInformation (const void* data, int sizeInByte
     // whose contents will have been created by the getStateInformation() call.
 }
 
+juce::AudioProcessorValueTreeState::ParameterLayout OutsetAudioProcessor::createAudioParameters()
+{
+    juce::AudioProcessorValueTreeState::ParameterLayout layout;
+
+    // Level Parameters (6)
+    juce::NormalisableRange<float> levelRange(0.0f, 1.0f, 0.01f);
+    for (int i = 1; i <= 6; ++i)
+    {
+        layout.add(std::make_unique<juce::AudioParameterFloat>(
+            juce::ParameterID("LEVEL_" + juce::String(i), 1),
+            "Level" + juce::String(i),
+            levelRange,
+            0.5f));
+    }
+
+    // Fine Parameters (6)
+    juce::NormalisableRange<float> fineRange(0.0f, 100.0f, 1.0f);
+    for (int i = 1; i <= 6; ++i)
+    {
+        layout.add(std::make_unique<juce::AudioParameterFloat>(
+            juce::ParameterID("FINE_" + juce::String(i), 1),
+            "Fine" + juce::String(i),
+            fineRange,
+            0.0f));
+    }
+
+    // Coarse Parameters (6)
+    juce::NormalisableRange<float> coarseRange(1.0f, 12.0f, 1.0f);
+    for (int i = 1; i <= 6; ++i)
+    {
+        layout.add(std::make_unique<juce::AudioParameterFloat>(
+            juce::ParameterID("COARSE_" + juce::String(i), 1),
+            "Coarse" + juce::String(i),
+            coarseRange,
+            1.0f));
+    }
+
+    // Cutoff Parameter (1)
+    juce::NormalisableRange<float> cutoffRange(20.0f, 20000.0f, 1.0f);
+    cutoffRange.setSkewForCentre(1000.0f);
+    layout.add(std::make_unique<juce::AudioParameterFloat>(
+        juce::ParameterID("CUTOFF", 1),
+        "Cutoff",
+        cutoffRange,
+        20000.0f));
+
+    // Resonance Parameter (1)
+    juce::NormalisableRange<float> resonanceRange(0.1f, 10.0f, 0.1f);
+    layout.add(std::make_unique<juce::AudioParameterFloat>(
+        juce::ParameterID("RESONANCE", 1),
+        "Resonance",
+        resonanceRange,
+        0.707f));
+
+    // Attack Parameters (6)
+    juce::NormalisableRange<float> attackRange(0.0f, 5.0f, 0.01f);
+    attackRange.setSkewForCentre(1.0f);
+    for (int i = 1; i <= 6; ++i)
+    {
+        layout.add(std::make_unique<juce::AudioParameterFloat>(
+            juce::ParameterID("ATTACK_" + juce::String(i), 1),
+            "Attack" + juce::String(i),
+            attackRange,
+            0.1f));
+    }
+
+    // Decay Parameters (6)
+    juce::NormalisableRange<float> decayRange(0.0f, 5.0f, 0.01f);
+    decayRange.setSkewForCentre(1.0f);
+    for (int i = 1; i <= 6; ++i)
+    {
+        layout.add(std::make_unique<juce::AudioParameterFloat>(
+            juce::ParameterID("DECAY_" + juce::String(i), 1),
+            "Decay" + juce::String(i),
+            decayRange,
+            0.1f));
+    }
+
+    // Release Parameters (6)
+    juce::NormalisableRange<float> releaseRange(0.0f, 5.0f, 0.01f);
+    releaseRange.setSkewForCentre(1.0f);
+    for (int i = 1; i <= 6; ++i)
+    {
+        layout.add(std::make_unique<juce::AudioParameterFloat>(
+            juce::ParameterID("RELEASE_" + juce::String(i), 1),
+            "Release" + juce::String(i),
+            releaseRange,
+            0.1f));
+    }
+
+    // Sustain Parameters (6)
+    juce::NormalisableRange<float> sustainRange(0.0f, 1.0f, 0.01f);
+    for (int i = 1; i <= 6; ++i)
+    {
+        layout.add(std::make_unique<juce::AudioParameterFloat>(
+            juce::ParameterID("SUSTAIN_" + juce::String(i), 1),
+            "Sustain" + juce::String(i),
+            sustainRange,
+            0.8f));
+    }
+
+    // Alg Index Parameter (1)
+    juce::NormalisableRange<float> algIndexRange(0.0f, 31.0f, 1.0f);
+    layout.add(std::make_unique<juce::AudioParameterFloat>(
+        juce::ParameterID("ALG_INDEX", 1),
+        "Alg Index",
+        algIndexRange,
+        0.0f));
+
+    return layout;
+}
+
+
 //==============================================================================
 // This creates new instances of the plugin..
 juce::AudioProcessor* JUCE_CALLTYPE createPluginFilter()

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -54,6 +54,9 @@ public:
     //==============================================================================
     void getStateInformation (juce::MemoryBlock& destData) override;
     void setStateInformation (const void* data, int sizeInBytes) override;
+    
+    juce::AudioProcessorValueTreeState::ParameterLayout createAudioParameters();
+    juce::AudioProcessorValueTreeState apvts {*this, nullptr, "Parameters", createAudioParameters()};
 
 private:
     juce::MidiKeyboardState keyboardState;


### PR DESCRIPTION
fully implement AudioProcessorValueTreeState and attach all sliders to their corresponding backend parameters.

(code to test this is commented out at the bottom of the process block in pluginprocessor.cpp)