### PR TITLE
add and apply colors singleton

### DIFF
--- a/Builds/MacOSX/Colors.cpp
+++ b/Builds/MacOSX/Colors.cpp
@@ -1,0 +1,13 @@
+//
+//  Colors.cpp
+//  Outset
+//
+//  Created by Race Williams on 4/8/25.
+//
+
+#include "Colors.h"
+
+Colors &colors() {
+    static Colors instance;
+    return instance;
+}

--- a/Builds/MacOSX/Colors.h
+++ b/Builds/MacOSX/Colors.h
@@ -1,0 +1,18 @@
+//
+//  Colors.h
+//  Outset
+//
+//  Created by Race Williams on 4/8/25.
+//
+
+#pragma once
+
+#include <JuceHeader.h>
+
+struct Colors {
+    juce::Colour mainBlue = juce::Colour(0x91, 0xC9, 0xB5);
+    juce::Colour accentBlue = juce::Colour(0x5B, 0x8F, 0x7E);
+    juce::Colour bgColor = juce::Colour(0x1A, 0x1A, 0x1A);
+};
+
+Colors &colors();

--- a/Outset.jucer
+++ b/Outset.jucer
@@ -83,6 +83,8 @@
         <FILE id="QGE4tF" name="OscComp.h" compile="0" resource="0" file="Source/GUI/OscComp.h"/>
         <FILE id="qfQrAq" name="EnvComp.cpp" compile="1" resource="0" file="Source/GUI/EnvComp.cpp"/>
         <FILE id="Ex0nPe" name="EnvComp.h" compile="0" resource="0" file="Source/GUI/EnvComp.h"/>
+        <FILE id="RyL90K" name="Colors.h" compile="0" resource="0" file="Source/GUI/Colors.h"/>
+        <FILE id="XnsOrQ" name="Colors.cpp" compile="1" resource="0" file="Source/GUI/Colors.cpp"/>
         <FILE id="MsK9Ch" name="LFOComp.cpp" compile="1" resource="0" file="Source/GUI/LFOComp.cpp"/>
         <FILE id="PCUPkB" name="LFOComp.h" compile="0" resource="0" file="Source/GUI/LFOComp.h"/>
         <FILE id="Z2Dvd8" name="KeyboardComp.cpp" compile="1" resource="0"

--- a/Source/GUI/Colors.cpp
+++ b/Source/GUI/Colors.cpp
@@ -1,0 +1,16 @@
+/*
+  ==============================================================================
+
+    Colors.cpp
+    Created: 8 Apr 2025 1:27:11pm
+    Author:  Race Williams
+
+  ==============================================================================
+*/
+
+#include "Colors.h"
+
+Colors &colors() {
+    static Colors instance;
+    return instance;
+}

--- a/Source/GUI/Colors.h
+++ b/Source/GUI/Colors.h
@@ -1,0 +1,29 @@
+/*
+  ==============================================================================
+
+    Colors.h
+    Created: 8 Apr 2025 1:27:11pm
+    Author:  Race Williams
+
+  ==============================================================================
+*/
+
+#pragma once
+
+#include <JuceHeader.h>
+
+// A singleton for Juce colours.
+// If we want to implement color schemes later, we just need to update this object,
+// not every single UI object independently.
+struct Colors {
+    juce::Colour main = juce::Colour(0x91, 0xC9, 0xB5);
+    juce::Colour accent = juce::Colour(0x5B, 0x8F, 0x7E);
+    juce::Colour bg = juce::Colour(0x1A, 0x1A, 0x1A);
+    
+    juce::Colour white = juce::Colour(0xFF, 0xFF, 0xFF);
+    juce::Colour black = juce::Colour(0x00, 0x00, 0x00);
+    
+    juce::Colour gridlines = white.withAlpha(0.2f);
+};
+
+Colors &colors();

--- a/Source/GUI/EnvComp.cpp
+++ b/Source/GUI/EnvComp.cpp
@@ -1,4 +1,6 @@
 #include <JuceHeader.h>
+
+#include "Colors.h"
 #include "EnvComp.h"
 
 //==============================================================================
@@ -16,16 +18,11 @@ EnvComp::EnvComp(int num, juce::AudioProcessorValueTreeState& apvtsRef)
     initializeSlider(sustainSlider, "S", 0.0, 1.0, 0.01, 0.8, false);
     initializeSlider(releaseSlider, "R", 0.0, 5.0, 0.01, 0.1, true);
     
-    // Kind of just guessed on these colors. Perhaps later we can have some
-    // global color obj.
-    juce::Colour mainBlue(0x91, 0xC9, 0xB5);
-    juce::Colour accentBlue(0x5B, 0x8F, 0x7E);
-    
     for (auto* slider : {&attackSlider, &decaySlider, &sustainSlider, &releaseSlider})
     {
-        slider->setColour(juce::Slider::rotarySliderFillColourId, mainBlue);
-        slider->setColour(juce::Slider::rotarySliderOutlineColourId, accentBlue);
-        slider->setColour(juce::Slider::thumbColourId, juce::Colours::white);
+        slider->setColour(juce::Slider::rotarySliderFillColourId, colors().main);
+        slider->setColour(juce::Slider::rotarySliderOutlineColourId, colors().accent);
+        slider->setColour(juce::Slider::thumbColourId, colors().white);
     }
 }
 
@@ -54,19 +51,16 @@ void EnvComp::initializeSlider(juce::Slider& slider, const juce::String& name, d
         addAndMakeVisible(*label);
         label->setText(name, juce::dontSendNotification);
         label->setJustificationType(juce::Justification::centredLeft);
-        label->setFont(juce::Font(14.0f, juce::Font::bold));
-        label->setColour(juce::Label::textColourId, juce::Colour(0x91, 0xC9, 0xB5));
+        label->setFont(juce::Font(juce::FontOptions(14.0f, juce::Font::bold)));
+        label->setColour(juce::Label::textColourId, colors().main);
     }
 }
 
 void EnvComp::paint(juce::Graphics& g)
 {
-    // Off-black
-    // TODO: use the colors in the notion
-    g.fillAll(juce::Colour(0x1A, 0x1A, 0x1A));
+    g.fillAll(colors().bg);
 
-    // Border
-    g.setColour(juce::Colour(0x5B, 0x8F, 0x7E));
+    g.setColour(colors().accent);
     g.drawRect(getLocalBounds(), 1);
 
     // Draw ADSR graph
@@ -95,19 +89,15 @@ void EnvComp::paint(juce::Graphics& g)
     juce::Path adsrPath;
     adsrPath.startNewSubPath(x, y);
     
-    // Attack segment
     adsrPath.lineTo(x + attackWidth, peakY);
     x += attackWidth;
-    // Decay segment
     adsrPath.lineTo(x + decayWidth, sustainY);
     x += decayWidth;
-    // Sustain segment
     adsrPath.lineTo(x + sustainWidth, sustainY);
     x += sustainWidth;
-    // Release segment
     adsrPath.lineTo(x + releaseWidth, y);
 
-    g.setColour(juce::Colour(0x91, 0xC9, 0xB5));
+    g.setColour(colors().main);
     g.strokePath(adsrPath, juce::PathStrokeType(2.0f));
     
     // Gradient
@@ -116,22 +106,14 @@ void EnvComp::paint(juce::Graphics& g)
     fillPath.lineTo(graphBounds.getX(), graphBounds.getBottom());
     fillPath.closeSubPath();
     g.setGradientFill(juce::ColourGradient(
-        juce::Colour(0x91, 0xC9, 0xB5).withAlpha(0.15f),
+        colors().main.withAlpha(0.15f),
         graphBounds.getX(), graphBounds.getY(),
-        juce::Colour(0x91, 0xC9, 0xB5).withAlpha(0.05f),
+        colors().main.withAlpha(0.05f),
         graphBounds.getX(), graphBounds.getBottom(),
         false));
     g.fillPath(fillPath);
     
-//    bool debug = false;
-//    if (!debug) return;
-//    bounds = getLocalBounds();
-//    width = bounds.getWidth();
-//    height = bounds.getHeight();
-//    g.setColour(juce::Colours::grey);
-    
-    // Grid lines
-    g.setColour(juce::Colours::white.withAlpha(0.2f));
+    g.setColour(colors().gridlines);
     for (int i = 1; i < 5; ++i)
     {
         float xPos = graphBounds.getX() + (graphBounds.getWidth() * i) / 5.0f;
@@ -143,8 +125,8 @@ void EnvComp::paint(juce::Graphics& g)
         g.drawLine(graphBounds.getX(), yPos, graphBounds.getRight(), yPos, 1.0f);
     }
     
-    g.setColour(juce::Colour(0x91, 0xC9, 0xB5));
-    g.setFont(juce::Font(12.0f));
+    g.setColour(colors().main);
+    g.setFont(juce::Font(juce::FontOptions(12.0f)));
     
     auto valueStr = [](float value) { return juce::String(value, 2); };
     g.drawText(valueStr(attack), attackSlider.getBounds().translated(0, -15), juce::Justification::centred);

--- a/Source/GUI/FilterComp.cpp
+++ b/Source/GUI/FilterComp.cpp
@@ -10,26 +10,20 @@
 
 #include <JuceHeader.h>
 #include "FilterComp.h"
+#include "Colors.h"
 
 FilterComp::FilterComp(juce::AudioProcessorValueTreeState& apvtsRef) : apvtsRef(apvtsRef),
 cutoffAttachment(apvtsRef, "CUTOFF", cutoffSlider),
 resonanceAttachment(apvtsRef, "RESONANCE", resonanceSlider)
 {
-
-
-    juce::Label* label = nullptr;
-
-    // Copied from EnvComp.cpp
-    juce::Colour mainBlue(0x91, 0xC9, 0xB5);
-    juce::Colour accentBlue(0x5B, 0x8F, 0x7E);
     for (auto* slider : { &cutoffSlider, &resonanceSlider })
     {
         slider->setSliderStyle(juce::Slider::RotaryHorizontalVerticalDrag);
         slider->setTextBoxStyle(juce::Slider::NoTextBox, false, 50, 10);
 
-        slider->setColour(juce::Slider::rotarySliderFillColourId, mainBlue);
-        slider->setColour(juce::Slider::rotarySliderOutlineColourId, accentBlue);
-        slider->setColour(juce::Slider::thumbColourId, juce::Colours::white);
+        slider->setColour(juce::Slider::rotarySliderFillColourId, colors().main);
+        slider->setColour(juce::Slider::rotarySliderOutlineColourId, colors().accent);
+        slider->setColour(juce::Slider::thumbColourId, colors().white);
         slider->addListener(this);
     }
 
@@ -49,8 +43,8 @@ resonanceAttachment(apvtsRef, "RESONANCE", resonanceSlider)
     qLabel.setText("Q", juce::dontSendNotification);
     for (auto* label : { &freqLabel, &qLabel }) {
         label->setJustificationType(juce::Justification::centredLeft);
-        label->setFont(juce::Font(14.0f, juce::Font::bold));
-        label->setColour(juce::Label::textColourId, juce::Colour(0x91, 0xC9, 0xB5));
+        label->setFont(juce::Font(juce::FontOptions(14.0f, juce::Font::bold)));
+        label->setColour(juce::Label::textColourId, colors().main);
 
     }
     addAndMakeVisible(freqLabel);
@@ -62,8 +56,8 @@ resonanceAttachment(apvtsRef, "RESONANCE", resonanceSlider)
         textbox->setReturnKeyStartsNewLine(false);
         textbox->setText(juce::String(cutoffSlider.getValue()), false);
         textbox->setJustification(juce::Justification::centredTop);
-        textbox->applyFontToAllText(juce::Font(12.0f, juce::Font::plain));
-        textbox->applyColourToAllText(juce::Colour(0x91, 0xC9, 0xB5));
+        textbox->applyFontToAllText(juce::Font(juce::FontOptions(12.0f, juce::Font::plain)));
+        textbox->applyColourToAllText(colors().main);
     }
 
     // Cutoff text box setup
@@ -97,17 +91,14 @@ FilterComp::~FilterComp()
 
 void FilterComp::paint(juce::Graphics& g)
 {
-    // ===== Copied code from EnvComp.cpp ======
-    // Fill background
-    g.fillAll(juce::Colour(0x1A, 0x1A, 0x1A));
+    g.fillAll(colors().bg);
 
-    g.setColour(juce::Colour(0x5B, 0x8F, 0x7E));
+    g.setColour(colors().accent);
     g.drawRect(getLocalBounds(), 1);
     // Define drawing area for the frequency response (with margin)
     //auto drawArea = getLocalBounds().reduced(10);
 
     auto bounds = getLocalBounds().reduced(14); // padding
-    auto width = bounds.getWidth();
     auto height = bounds.getHeight() * 0.7;
     auto drawArea = bounds.withHeight(height);
 
@@ -126,7 +117,7 @@ void FilterComp::paint(juce::Graphics& g)
     // -=======================================-
 
     // Draw horizontal grid lines (for reference)
-    g.setColour(juce::Colours::grey);
+    g.setColour(colors().gridlines);
     bool debug = false;
     if(debug)
     {
@@ -241,7 +232,7 @@ void FilterComp::paint(juce::Graphics& g)
     }
 
     // Draw the frequency response curve in yellow
-    g.setColour(juce::Colour(0x91, 0xC9, 0xB5));
+    g.setColour(colors().main);
     g.strokePath(responseCurve, juce::PathStrokeType(2.0f));
 
     juce::Path fillPath = responseCurve;
@@ -249,9 +240,9 @@ void FilterComp::paint(juce::Graphics& g)
     fillPath.lineTo(drawArea.getX(), drawArea.getBottom());
     fillPath.closeSubPath();
     g.setGradientFill(juce::ColourGradient(
-        juce::Colour(0x91, 0xC9, 0xB5).withAlpha(0.15f),
+        colors().main.withAlpha(0.15f),
         drawArea.getX(), drawArea.getY(),
-        juce::Colour(0x91, 0xC9, 0xB5).withAlpha(0.05f),
+        colors().main.withAlpha(0.05f),
         drawArea.getX(), drawArea.getBottom(),
         false));
     g.fillPath(fillPath);

--- a/Source/GUI/LFOComp.cpp
+++ b/Source/GUI/LFOComp.cpp
@@ -9,8 +9,10 @@
 */
 
 #include <JuceHeader.h>
+
+#include "Colors.h"
 #include "LFOComp.h"
-//==============================================================================
+
 LFOComp::LFOComp(juce::AudioProcessorValueTreeState& apvtsRef) : apvtsRef(apvtsRef)
 {
     // In your constructor, you should add any child components, and
@@ -24,7 +26,7 @@ LFOComp::LFOComp(juce::AudioProcessorValueTreeState& apvtsRef) : apvtsRef(apvtsR
 
     auto drawable = std::make_unique<juce::DrawablePath>();
     drawable->setPath(next_trianglePath);
-    drawable->setFill(juce::Colours::white);
+    drawable->setFill(colors().white);
 
     next_b = std::make_unique<juce::DrawableButton>("next", juce::DrawableButton::ImageFitted);
     next_b->setImages(drawable.get());
@@ -99,23 +101,22 @@ LFOComp::~LFOComp()
 void LFOComp::paint (juce::Graphics& g)
 {
     juce::Rectangle<int> bounds = getLocalBounds();
-    g.fillAll(juce::Colours::skyblue);
+    g.fillAll(colors().bg);
 
-    g.setColour(juce::Colours::black);
+    g.setColour(colors().accent);
     g.drawRect(bounds, 1);
 
-    g.setColour(juce::Colours::black);
+    g.setColour(colors().black);
     g.setFont(juce::FontOptions(14.0f));
 
     int x = (bounds.getWidth() / 2) - bounds.getHeight() / 3;
     int y = bounds.getHeight() - bounds.getHeight() / 8;
     juce::Rectangle<int> centeredRect(bounds.getWidth()/8, 0, bounds.getWidth() * 3/ 4, bounds.getHeight() * 7 / 8);
 
-
-    g.setColour(juce::Colours::lightgrey);
+    g.setColour(colors().gridlines);
     g.fillRect(centeredRect);
 
-    g.setColour(juce::Colours::black);
+    g.setColour(colors().main);
     g.drawRect(centeredRect, 2);
 
     image = images[static_cast<int>(apvtsRef.getRawParameterValue("ALG_INDEX")->load())];

--- a/Source/GUI/OscComp.cpp
+++ b/Source/GUI/OscComp.cpp
@@ -7,8 +7,10 @@
 
   ==============================================================================
 */
-#include "OscComp.h"
 #include <string>
+
+#include "Colors.h"
+#include "OscComp.h"
 
 OscComp::OscComp(int num, juce::AudioProcessorValueTreeState& apvtsRef)
     : oscNum(num),
@@ -23,37 +25,27 @@ OscComp::OscComp(int num, juce::AudioProcessorValueTreeState& apvtsRef)
     initializeSlider(oscFineSlider, oscFineLabel, "Fine", juce::Slider::SliderStyle::RotaryHorizontalVerticalDrag, 0.0, 100.0, 1.0, 0.0);
     initializeSlider(oscCoarseSlider, oscCoarseLabel, "Coarse", juce::Slider::SliderStyle::RotaryHorizontalVerticalDrag, 1.0, 12.0, 1.0, 1.0);
     
-    // again kinda spamming the same colors everywhere, we can do a pr to pull it out
-    juce::Colour mainBlue(0x91, 0xC9, 0xB5);
-    juce::Colour accentBlue(0x5B, 0x8F, 0x7E);
-    
     for (auto* slider : {&oscLevelSlider, &oscFineSlider, &oscCoarseSlider})
     {
-        slider->setColour(juce::Slider::rotarySliderFillColourId, mainBlue);
-        slider->setColour(juce::Slider::rotarySliderOutlineColourId, accentBlue);
-        slider->setColour(juce::Slider::thumbColourId, juce::Colours::white);
+        slider->setColour(juce::Slider::rotarySliderFillColourId, colors().main);
+        slider->setColour(juce::Slider::rotarySliderOutlineColourId, colors().accent);
+        slider->setColour(juce::Slider::thumbColourId, colors().white);
     }
     
-    // TODO: juce funt deprecated
     for (auto* label : {&oscLevelLabel, &oscFineLabel, &oscCoarseLabel})
     {
-        label->setFont(juce::Font(14.0f, juce::Font::bold));
-        label->setColour(juce::Label::textColourId, mainBlue);
+        label->setFont(juce::Font(juce::FontOptions(14.0f, juce::Font::bold)));
+        label->setColour(juce::Label::textColourId, colors().main);
         label->setJustificationType(juce::Justification::centred);
     }
 }
 
 void OscComp::paint(juce::Graphics& g)
 {
-    // TODO: de-dupe colors
-    juce::Colour mainBlue(0x91, 0xC9, 0xB5);
-    juce::Colour accentBlue(0x5B, 0x8F, 0x7E);
-    juce::Colour backgroundColour(0x1A, 0x1A, 0x1A);
+    g.fillAll(colors().bg);
     
-    // bg and border
-    g.fillAll(backgroundColour);
-    g.setColour(accentBlue);
-    g.drawRect(getLocalBounds(), 1);
+    g.setColour(colors().accent);
+    // g.drawRect(getLocalBounds(), 1);
     
     // DRAW OSC
     auto bounds = getLocalBounds().reduced(14); // padding
@@ -80,7 +72,7 @@ void OscComp::paint(juce::Graphics& g)
         wavePath.lineTo(graphBounds.getX() + x, y);
     }
     
-    g.setColour(mainBlue);
+    g.setColour(colors().main);
     g.strokePath(wavePath, juce::PathStrokeType(2.0f));
     
     // classic gradient
@@ -89,15 +81,15 @@ void OscComp::paint(juce::Graphics& g)
     fillPath.lineTo(graphBounds.getX(), centerY);
     fillPath.closeSubPath();
     g.setGradientFill(juce::ColourGradient(
-        mainBlue.withAlpha(0.15f),
+        colors().main.withAlpha(0.15f),
         graphBounds.getX(), graphBounds.getY(),
-        mainBlue.withAlpha(0.05f),
+        colors().main.withAlpha(0.05f),
         graphBounds.getX(), graphBounds.getBottom(),
         false));
     g.fillPath(fillPath);
     
     // grid lines
-    g.setColour(juce::Colours::white.withAlpha(0.2f));
+    g.setColour(colors().gridlines);
     for (int i = 1; i < 5; ++i)
     {
         float xPos = graphBounds.getX() + (graphBounds.getWidth() * i) / 5.0f;
@@ -109,8 +101,8 @@ void OscComp::paint(juce::Graphics& g)
     g.drawLine(graphBounds.getX(), centerLine, graphBounds.getRight(), centerLine, 1.0f);
     
     // vals on sliders same as ENV
-    g.setColour(mainBlue);
-    g.setFont(juce::Font(12.0f));
+    g.setColour(colors().main);
+    g.setFont(juce::Font(juce::FontOptions(12.0f)));
     // lambda for printing the vals
     auto valueStr = [](float value) { return juce::String(value, 2); };
     g.drawText(valueStr(oscLevelSlider.getValue()),
@@ -171,5 +163,3 @@ void OscComp::sliderValueChanged(juce::Slider* slider)
 {
     repaint();
 }
-
-// I liberally removed some things here bc i didnt use them lmk if they are needed

--- a/Source/GUI/OscEnvTab.h
+++ b/Source/GUI/OscEnvTab.h
@@ -11,8 +11,9 @@
 #pragma once
 
 #include <JuceHeader.h>
-#include "OscEnvParent.h"
 
+#include "Colors.h"
+#include "OscEnvParent.h"
 
 // This component acts as the parent for the OscEnvParents. Switching tabs makes one of the 6 OscEnv Parents Visible.
 class OscEnvTab : public juce::TabbedComponent
@@ -21,18 +22,15 @@ public:
     OscEnvTab(juce::AudioProcessorValueTreeState& apvtsRef)
         : juce::TabbedComponent(juce::TabbedButtonBar::TabsAtTop)
     {
-        juce::Colour oscColor = juce::Colours::palevioletred;
         setTabBarDepth(30);
 
-        addTab("Osc 1", oscColor, new OscEnvParent(1, apvtsRef), true);
-        addTab("Osc 2", oscColor, new OscEnvParent(2, apvtsRef), true);
-        addTab("Osc 3", oscColor, new OscEnvParent(3, apvtsRef), true);
-        addTab("Osc 4", oscColor, new OscEnvParent(4, apvtsRef), true);
-        addTab("Osc 5", oscColor, new OscEnvParent(5, apvtsRef), true);
-        addTab("Osc 6", oscColor, new OscEnvParent(6, apvtsRef), true);
+        addTab("Osc 1", colors().main, new OscEnvParent(1, apvtsRef), true);
+        addTab("Osc 2", colors().main, new OscEnvParent(2, apvtsRef), true);
+        addTab("Osc 3", colors().main, new OscEnvParent(3, apvtsRef), true);
+        addTab("Osc 4", colors().main, new OscEnvParent(4, apvtsRef), true);
+        addTab("Osc 5", colors().main, new OscEnvParent(5, apvtsRef), true);
+        addTab("Osc 6", colors().main, new OscEnvParent(6, apvtsRef), true);
     }
 
     ~OscEnvTab() override = default;
 };
-
-

--- a/Source/GUI/PresetsComp.cpp
+++ b/Source/GUI/PresetsComp.cpp
@@ -9,6 +9,8 @@
 */
 
 #include <JuceHeader.h>
+
+#include "Colors.h"
 #include "PresetsComp.h"
 
 //==============================================================================
@@ -25,18 +27,13 @@ PresetsComp::~PresetsComp()
 
 void PresetsComp::paint (juce::Graphics& g)
 {
-    g.fillAll(juce::Colours::lightgrey);
+    g.fillAll(colors().bg);
 
-    g.setColour (juce::Colours::black);
-    g.drawRect (getLocalBounds(), 1);
-
-    g.setColour (juce::Colours::black);
-    g.setFont (juce::FontOptions (14.0f));
-    g.drawText ("Presets", getLocalBounds(), juce::Justification::centred, true);
+    g.setColour(colors().main);
+    g.setFont(juce::FontOptions(14.0f));
+    g.drawText("Presets", getLocalBounds(), juce::Justification::centred, true);
 }
 
 void PresetsComp::resized()
 {
-    
-
 }

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -11,7 +11,7 @@
 
 //==============================================================================
 OutsetAudioProcessorEditor::OutsetAudioProcessorEditor (OutsetAudioProcessor& p, juce::MidiKeyboardState& ks )
-    : AudioProcessorEditor (&p), audioProcessor (p), keyboard_comp(ks), osc_env_tab(audioProcessor.apvts), filter_comp(audioProcessor.apvts), lfo_comp(audioProcessor.apvts)
+: AudioProcessorEditor (&p), audioProcessor (p), filter_comp(audioProcessor.apvts), keyboard_comp(ks), lfo_comp(audioProcessor.apvts), osc_env_tab(audioProcessor.apvts)
 {
     double ratio = 4.0 / 3.0;
     setResizeLimits(400, 400 / ratio, 1200, 1200 / ratio);
@@ -34,7 +34,7 @@ OutsetAudioProcessorEditor::~OutsetAudioProcessorEditor()
 void OutsetAudioProcessorEditor::paint (juce::Graphics& g)
 {
     // Probably will get rid of this because it'll get covered by the components
-    g.fillAll (getLookAndFeel().findColour (juce::ResizableWindow::backgroundColourId));
+    // g.fillAll (getLookAndFeel().findColour (juce::ResizableWindow::backgroundColourId));
 
     //g.setColour (juce::Colours::white);
     //g.setFont (15.0f);


### PR DESCRIPTION
Hi, I updated the UI a bit.
Changes:
- added `struct Colors` singleton to contain common `juce::Colours` defs. It'll be easier this way if we want to do a colorscheme or something later
- switched over UI components that used redundant `juce::Colours` defs
- OscComp UI tabs aren't pink anymore ;(

<img width="821" alt="image" src="https://github.com/user-attachments/assets/992aea88-12c5-4e97-8660-69d8c8879f20" />