### PR TITLE
Fix FM implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/JuceLibraryCode
 **/.DS_Store
 **/Outset.filtergraph
+**.vs

--- a/Outset.jucer
+++ b/Outset.jucer
@@ -5,6 +5,7 @@
               pluginCharacteristicsValue="pluginIsSynth,pluginProducesMidiOut,pluginWantsMidiIn">
   <MAINGROUP id="YW4tEd" name="Outset">
     <GROUP id="{08B4255C-6792-1333-C4D2-110BD672E3EA}" name="Source">
+      <FILE id="T2ypSV" name="AlgSpace.h" compile="0" resource="0" file="Source/AlgSpace.h"/>
       <FILE id="psm5WR" name="VoiceHandler.h" compile="0" resource="0" file="Source/VoiceHandler.h"/>
       <FILE id="dU77Tv" name="Operator.cpp" compile="1" resource="0" file="Source/Operator.cpp"/>
       <FILE id="bvIe14" name="Operator.h" compile="0" resource="0" file="Source/Operator.h"/>

--- a/Source/AlgSpace.h
+++ b/Source/AlgSpace.h
@@ -1,0 +1,250 @@
+/*
+  ==============================================================================
+
+    AlgSpace.h
+    Created: 6 Sep 2025 3:21:31pm
+    Author:  ryanb
+
+  ==============================================================================
+*/
+
+#pragma once
+#include <JuceHeader.h>
+#include "Operator.h"
+class AlgSpace
+{
+public:
+
+	AlgSpace() {};
+	~AlgSpace() {};
+
+    /*
+	setAlgorithm will set modulation routing, assign carriers, and set feedback 
+	for all 32 algorithms
+	*/
+	void setAlgorithm(std::vector<Operator>& op, int algIndex) {
+		if (algIndex < 0 || algIndex >= algTable.size()) {
+			jassertfalse;
+			return;
+		}
+		const auto& alg = algTable[algIndex];
+		// map is one-based indexing, hence - 1
+		for (const auto& routing : alg.routings)
+			op[routing.modulated - 1].addModOperator(&op[routing.modulator - 1]);
+		for (int c : alg.carriers)
+			op[c - 1].setCarrier(true);
+		for (int f : alg.feedbackOperator)
+			op[f - 1].setFeedback(true);
+	}
+private:
+	struct Routing {
+		int modulated;
+		int modulator;
+	};
+	struct Description {
+		std::vector<Routing> routings;
+		std::vector<int> carriers;
+		int feedbackOperator; // -1 means no feedback opereator
+	};
+	const std::vector<Description> algTable = {
+		/*
+		Format:
+		{ { {modulated, modulator}, ... }, // routings
+			{carriers}, // carrier indeces
+			feedbackOperator } // feedback operator
+			// These are ONE indexed to be 1-1 with alg graphs
+		*/
+		// Alg 1
+		{
+			{{1, 2}, {3, 4}, {4, 5}, {5, 6}},
+			{1, 3},
+			6
+		},
+		// Alg 2
+		{
+			{{1, 2}, {3, 4}, {4, 5}, {5, 6}},
+			{1, 3},
+			2
+		},
+		// Alg 3
+		{
+			{{1, 2}, {2, 3}, {4, 5}, {5, 6}},
+			{1, 4},
+			6
+		},
+		// Alg 4
+		{
+			{{1, 2}, {2, 3}, {4, 5}, {5, 6}, {6, 4}},
+			{ 1, 4 },
+			-1
+		},
+		// Alg 5
+		{
+			{ { 1, 2 }, {3, 4}, {5, 6}},
+			{1, 3, 5},
+			6
+		},
+		// Alg 6
+		{
+			{ { 1, 2 }, {3, 4}, {5, 6}, { 6, 5 }},
+			{1, 3, 5},
+			-1
+		},
+		// Alg 7
+		{
+			{{1 ,2}, {3, 4}, {3, 5}, {5, 6}},
+			{1, 3},
+			6
+		},
+		// Alg 8
+		{
+			{{1 ,2}, {3, 4}, {3, 5}, {5, 6}},
+			{1, 3},
+			4
+		},
+		// Alg 9
+		{
+			{{1 ,2}, {3, 4}, {3, 5}, {5, 6}},
+			{1, 3},
+			2
+		},
+		// Alg 10
+		{
+			{{1, 2}, {2, 3}, {4, 5}, {4, 6}},
+			{1, 4},
+			3
+		},
+		// Alg 11
+		{
+			{{1, 2}, {2, 3}, {4, 5}, {4, 6}},
+			{1, 4},
+			6
+		},
+		// Alg 12
+		{
+			{{1, 2}, {3, 4}, {3, 5}, {3,6}},
+			{1, 3},
+			2
+		},
+		// Alg 13
+		{
+			{ { 1, 2 }, { 3, 4 }, { 3, 5 }, { 3,6 }},
+			{ 1, 3 },
+			6
+		},
+		// Alg 14
+		{
+			{{1, 2}, {3, 4},{4, 5}, {4, 6}},
+			{1, 3},
+			6
+		},
+		// Alg 15
+		{
+			{{1, 2}, {3, 4},{4, 5}, {4, 6}},
+			{1, 3},
+			2
+		},
+		// Alg 16
+		{
+			{{1, 2}, {1, 3}, {1, 5}, {3, 4}, {5, 6}},
+			{1},
+			6
+		},
+		// Alg 17
+		{
+			{{1, 2}, {1, 3}, {1, 5}, {3, 4}, {5, 6}},
+			{1},
+			2
+		},
+		// Alg 18 (TODO: gui is wrong)
+		{
+			{{1, 2}, {1, 3}, {1, 4}, {4, 5}, {5, 6}},
+			{1},
+			3
+		},
+		// Alg 19
+		{
+			{{1, 2}, {2, 3}, {4, 6}, {5, 6}},
+			{1, 4 ,5},
+			6
+		},
+		// Alg 20
+		{
+			{{1, 3}, {2, 3}, {4, 5}, {4, 6}},
+			{1, 2, 4},
+			3
+		},
+		// Alg 21
+		{
+			{{1, 3}, {2, 3}, {4, 6}, {5, 6}},
+			{1, 2, 4, 5},
+			3
+		},
+		// Alg 22
+		{
+			{{1, 2}, {3, 6}, {4, 6}, {5, 6}},
+			{1, 3, 4, 5},
+			6
+		},
+		// Alg 23
+		{
+			{{2, 3}, {4, 6}, {5, 6}},
+			{1, 2, 4, 5},
+			6
+		},
+		// Alg 24
+		{
+			{{3, 6}, {4, 6}, {5, 6}},
+			{1, 2, 3, 4, 5},
+			6
+		},
+		// Alg 25
+		{
+			{{4, 6}, {5, 6}},
+			{1, 2, 3, 4, 5},
+			6
+		},
+		// Alg 26
+		{
+			{{2, 3}, {4, 5}, {4, 6}},
+			{1, 2, 4},
+			6
+		},
+		// Alg 27
+		{
+			{{2, 3}, {4, 5}, {4, 6}},
+			{1, 2, 4},
+			3
+		},
+		// Alg 28
+		{
+			{{1, 2}, {3, 4}, {4, 5}},
+			{1, 3, 6},
+			5
+		},
+		// Alg 29 
+		{
+			{{3, 4}, {5, 6}},
+			{1, 2, 3, 5},
+			6
+		},
+		// Alg 30
+		{
+			{{3, 4}, {4, 5}},
+			{1, 2, 3, 6},
+			5
+		},
+		// Alg 31
+		{
+			{{5, 6}},
+			{1, 2, 3, 4, 5},
+			6
+		},
+		// Alg 32
+		{
+			{{}},
+			{1, 2, 3, 4, 5, 6},
+			6
+		},
+	};
+};

--- a/Source/AlgSpace.h
+++ b/Source/AlgSpace.h
@@ -15,8 +15,8 @@ class AlgSpace
 {
 public:
 
-	AlgSpace() {};
-	~AlgSpace() {};
+	AlgSpace() = default;
+	~AlgSpace() = default;
 
     /*
 	setAlgorithm will set modulation routing, assign carriers, and set feedback 
@@ -27,26 +27,30 @@ public:
 			jassertfalse;
 			return;
 		}
+		// clear routings
+		for (auto& opRef : op)
+			opRef.resetRouting();
+
 		const auto& alg = algTable[algIndex];
 		// map is one-based indexing, hence - 1
 		for (const auto& routing : alg.routings)
 			op[routing.modulated - 1].addModOperator(&op[routing.modulator - 1]);
 		for (int c : alg.carriers)
 			op[c - 1].setCarrier(true);
-		for (int f : alg.feedbackOperator)
-			op[f - 1].setFeedback(true);
+		if (alg.feedbackOperator != -1)
+			op[alg.feedbackOperator - 1].setFeedback(true);
 	}
 private:
-	struct Routing {
+	struct algRouting {
 		int modulated;
 		int modulator;
 	};
-	struct Description {
-		std::vector<Routing> routings;
+	struct algDescription {
+		std::vector<algRouting> routings;
 		std::vector<int> carriers;
 		int feedbackOperator; // -1 means no feedback opereator
 	};
-	const std::vector<Description> algTable = {
+	const std::vector<algDescription> algTable = {
 		/*
 		Format:
 		{ { {modulated, modulator}, ... }, // routings

--- a/Source/Operator.cpp
+++ b/Source/Operator.cpp
@@ -15,6 +15,15 @@ Operator::Operator()
 	sampleRate = 48000;
 	env.setSampleRate(48000);
 	env.setParameters({ 0.1f, 0.1f, 0.8f, 0.1f });
+	// Initialise runtime variables to safe defaults
+	note = -1;
+	cached = false;
+	lastSample = 0.f;
+	cachedSample = 0.f;
+	ratio = 1.f;
+	level = 0.5f;
+	tuning = 0.f;
+	baseFrequency = 261.63f; // Middle C reference
 }
 
 Operator::Operator(int index)
@@ -26,9 +35,13 @@ Operator::Operator(int index)
 	level = 0.5f;
 	osc.amplitude = 0.5f;
 	ratio = 1.f;
-	frequency = 261.63f;
+	baseFrequency = 261.63f;
 	tuning = 0;
-	setFrequency(261.63f);
+	note = -1; // not assigned yet
+	setFrequency(baseFrequency);
+	cached = false;
+	lastSample = 0.f;
+	cachedSample = 0.f;
 }
 
 Operator::~Operator()
@@ -45,16 +58,18 @@ void Operator::init(int opIndex_) // deprecated
 }
 
 void Operator::reset(float fs) {
-	fs = sampleRate;
+	sampleRate = fs;
 	env.setSampleRate(fs);
 	osc.reset();
 	freqSmooth.reset(int(50));
 	ampSmooth.reset(int(50));
+	// do not alter baseFrequency here; it depends on the current note/ratio/tuning
+	cached = false;
 
 }
 void Operator::resetCache() {
 	cached = false;
-	//lastSample = 0.f;
+	lastSample = 0.f; // important so feedback from a previous note doesn't affect the next
 	cachedSample = 0.f;
 }
 float Operator::getCachedSample()
@@ -108,7 +123,7 @@ float Operator::getNextSample()
 	float modSample = 0.f;
 	if (feedback)
 	{
-		modSample += lastSample;
+		modSample += lastSample * 0.25f; // scale feedback to prevent runaway & pitch shift
 	}
 	if (!modOperators.empty()) {
 		for (auto mod : modOperators)
@@ -118,9 +133,13 @@ float Operator::getNextSample()
 			}
 		}
 	}
-
-
-	setFrequency(frequency + 1000 * modSample);
+	// --- FM deviation scaling (simple): deviation proportional to base freq ---
+	// Previous formula doubled baseFrequency every sample (base + base) causing octave shift.
+	constexpr float modulationIndex = 1.f; // TODO: expose as parameter
+	float deviation = modulationIndex * modSample * baseFrequency; // Hz deviation
+	float currentFreq = baseFrequency + deviation;
+	if (currentFreq < 0.f) currentFreq = 0.f;
+	setFrequency(currentFreq); // do FM
 
 	ampSmooth.setTargetValue(osc.amplitude * level * currentEnv);
 	output = osc.nextSample() * ampSmooth.getNextValue();
@@ -131,8 +150,10 @@ float Operator::getNextSample()
 void Operator::updateRatio(float ratio_)
 {
 	ratio = ratio_;
-	float freq = ratio * 440.0f * std::exp2(float(note - 69 + tuning) / 12.0f); // this is the midi to freq formula
-	frequency = freq;
+	if (note >= 0) {
+		float freq = ratio * 440.0f * std::exp2(float(note - 69 + tuning) / 12.0f);
+		baseFrequency = freq;
+	}
 }
 
 void Operator::updateLevel(float level_)
@@ -142,8 +163,10 @@ void Operator::updateLevel(float level_)
 void Operator::updateTuning(float fine, float coarse)
 {
 	tuning = coarse + fine / 100.0f;
-	float freq = ratio * 440.0f * std::exp2(float(note - 69 + tuning) / 12.0f); // this is the midi to freq formula
-	frequency = freq;
+	if (note >= 0) {
+		float freq = ratio * 440.0f * std::exp2(float(note - 69 + tuning) / 12.0f);
+		baseFrequency = freq;
+	}
 }
 
 void Operator::noteOn(int note_, int velocity)
@@ -151,11 +174,13 @@ void Operator::noteOn(int note_, int velocity)
 	note = note_;
 	float freq = ratio * 440.0f * std::exp2(float(note - 69 + tuning) / 12.0f); // this is the midi to freq formula
 	DBG("Operator " << opIndex << " initial freq: " << freq);
-	//setFrequency(freq);
-	frequency = freq;
+	baseFrequency = freq; // stable base
+	setFrequency(baseFrequency); // ensure oscillator increment set immediately
 	osc.amplitude = (velocity / 127.0f) * 0.5f;
 	env.noteOn();
 	DBG("Operator " << opIndex << " second freq: " << osc.getFrequency());
+	lastSample = 0.f; // clear feedback for consistent retrigger
+	cached = false; // force recache in modulators
 
 }
 void Operator::noteOff()

--- a/Source/Operator.cpp
+++ b/Source/Operator.cpp
@@ -93,6 +93,12 @@ void Operator::addModOperator(Operator* mod)
 	modOperators.push_back(mod);
 }
 
+void Operator::resetRouting()
+{
+	modOperators.clear();
+	setFeedback(false);
+	setCarrier(false);
+}
 
 
 float Operator::getNextSample()

--- a/Source/Operator.h
+++ b/Source/Operator.h
@@ -50,7 +50,7 @@ private:
 	float lastSample = 0.f;
 	float cachedSample;
 	int opIndex;
-	float sampleRate, frequency, level, ratio, tuning;
+	float sampleRate, baseFrequency, level, ratio, tuning;
 	int note;
 	std::vector<Operator*> modOperators;
 	juce::SmoothedValue<float, juce::ValueSmoothingTypes::Multiplicative> freqSmooth; //multiplicative for frequency per juce docs

--- a/Source/Operator.h
+++ b/Source/Operator.h
@@ -24,6 +24,7 @@ public:
 
 	void setLevel(float amplitude);
 	void addModOperator(Operator* modulator);
+	void resetRouting();
 	// having multiple operators has to be handled carefully. We cannot call nextSample() multiple
 	float getNextSample();
 	void noteOn(int note, int velocity);

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -167,12 +167,7 @@ void OutsetAudioProcessor::processBlock (juce::AudioBuffer<float>& buffer, juce:
   
     double cutoff = apvts.getRawParameterValue("CUTOFF")->load();
 	double q = apvts.getRawParameterValue("RESONANCE")->load();
-    double attack1 = apvts.getRawParameterValue("ATTACK_1")->load();
-	double decay1 = apvts.getRawParameterValue("DECAY_1")->load();
-	double sustain1 = apvts.getRawParameterValue("SUSTAIN_1")->load();
-	double release1 = apvts.getRawParameterValue("RELEASE_1")->load();
-    double fine1 = apvts.getRawParameterValue("FINE_1")->load();
-
+    int algIndex = apvts.getRawParameterValue("ALG_INDEX")->load();
     const int numOperators = 6;
 
 	std::vector<float> level(numOperators);
@@ -202,6 +197,7 @@ void OutsetAudioProcessor::processBlock (juce::AudioBuffer<float>& buffer, juce:
     
 	filter->setCutoffFrequency(cutoff);
 	filter->setResonance(q);
+    synth.updateAlgorithm(algIndex);
 	for (int i = 0; i < 6; i++) {
 
 		synth.updateOsc(fine[i], coarse[i], level[i], ratio[i], i);

--- a/Source/Synth.cpp
+++ b/Source/Synth.cpp
@@ -67,7 +67,10 @@ void Synth::noteOff(int note)
     voiceHandler.noteOff(note);
     DBG("NOTE OFF " << note);
 }
-
+void Synth::updateAlgorithm(int algIndex_)
+{
+    voiceHandler.updateAlgorithm(algIndex_);
+}
 void Synth::updateOsc(float fine, float coarse, float level, float ratio, int index)
 {
     // In a polyphonic setting, apply oscillator adjustments

--- a/Source/Synth.h
+++ b/Source/Synth.h
@@ -26,10 +26,10 @@ public:
     void midiMessage(uint8_t data0, uint8_t data1, uint8_t data2);
     void updateADSR(float attack, float decay, float sustain, float release, int index); // May need an additional int input for what oscillator is being updated depending on our desired topology
     void updateOsc(float fine, float coarse, float level, float ratio, int index);
+    void updateAlgorithm(int algIndex_);
 private:
     void noteOn(int note, int velocity);
     void noteOff(int note);
-    
     float sampleRate;
     VoiceHandler voiceHandler; //will eventually be a collection of voices. likely a vector
     //NoiseGenerator noiseGen;

--- a/Source/Voice.h
+++ b/Source/Voice.h
@@ -19,14 +19,15 @@ struct Voice {
             op.emplace_back(i);
             op[i].init(i);
         }
-        op[0].addModOperator(&op[1]);
-        DBG("Op " << 0 << "modulated by Op " << 1);
-        for (int i = 2; i < 5; i++) {
-            op[i].addModOperator(&op[i + 1]);
-            DBG("Op " << i << "modulated by Op " << i + 1);
-        }
-		op[0].setCarrier(true);
-        op[2].setCarrier(true);
+
+  //      op[0].addModOperator(&op[1]);
+  //      DBG("Op " << 0 << "modulated by Op " << 1);
+  //      for (int i = 2; i < 5; i++) {
+  //          op[i].addModOperator(&op[i + 1]);
+  //          DBG("Op " << i << "modulated by Op " << i + 1);
+  //      }
+		//op[0].setCarrier(true);
+  //      op[2].setCarrier(true);
     }
     
     void reset(float sampleRate) {


### PR DESCRIPTION
Whoops - I wrote some bad code. The FM implementation was shotty as heck and only worked through the grace of the sound god(s).

## High level overview:
Fix pitch-drift bug where note content changes between identicle note events.

### Initialization
- SampleRate, Note, cached, lastSample and baseFrequency are preset to guard against unpredictable behavior after reset or instantiation.
### Reset methods
- Operator reset method had an incorrect assignment where it actually overwrote the incoming sample rate.
- Reset cache now actually removes feedback and cached output so there is not random garbage sitting in the cache when it is reset.
### NoteOn
- Calling setFrequency here first is important so the phase increment (inc) is correct on noteOn events.
- clear the cache after the noteOn event 

## To do (or not)
- implement modulation depth as a parameter
  - I think we discussed this and decided not to. Might be worth revisiting.